### PR TITLE
Fixed format string in order to use with older python3 versions

### DIFF
--- a/shellcode/generate_hashes.py
+++ b/shellcode/generate_hashes.py
@@ -11,16 +11,16 @@ crypt_key = random.randint(0, 0xFFFFFFFF)
 with open("api_resolve.h", "r") as _file:
     contents = _file.read(-1)
 
-hashes = f"#define CRYPT_KEY {hex(crypt_key)}\n"
-hashes += f"#define CRYPTED_HASH_KERNEL32 {hex(hash_djb2("KERNEL32.DLL".lower()) ^ crypt_key)}\n"
-hashes += f"#define CRYTPED_HASH_CREATETHREAD {hex(hash_djb2("CreateThread") ^ crypt_key)}\n"
-hashes += f"#define CRYPTED_HASH_LOADLIBRARYA {hex(hash_djb2("LoadLibraryA") ^ crypt_key)}\n"
-hashes += f"#define CRYPTED_HASH_VIRTUALALLOC {hex(hash_djb2("VirtualAlloc") ^ crypt_key)}\n"
-hashes += f"#define CRYPTED_HASH_VIRTUALFREE {hex(hash_djb2("VirtualFree") ^ crypt_key)}\n"
-hashes += f"#define CRYPTED_HASH_VIRTUALPROTECT {hex(hash_djb2("VirtualProtect") ^ crypt_key)}\n"
+hashes = f'#define CRYPT_KEY {hex(crypt_key)}\n'
+hashes += f'#define CRYPTED_HASH_KERNEL32 {hex(hash_djb2("KERNEL32.DLL".lower()) ^ crypt_key)}\n'
+hashes += f'#define CRYTPED_HASH_CREATETHREAD {hex(hash_djb2("CreateThread") ^ crypt_key)}\n'
+hashes += f'#define CRYPTED_HASH_LOADLIBRARYA {hex(hash_djb2("LoadLibraryA") ^ crypt_key)}\n'
+hashes += f'#define CRYPTED_HASH_VIRTUALALLOC {hex(hash_djb2("VirtualAlloc") ^ crypt_key)}\n'
+hashes += f'#define CRYPTED_HASH_VIRTUALFREE {hex(hash_djb2("VirtualFree") ^ crypt_key)}\n'
+hashes += f'#define CRYPTED_HASH_VIRTUALPROTECT {hex(hash_djb2("VirtualProtect") ^ crypt_key)}\n'
 
-hashes += f"#define CRYPTED_HASH_SHLWAPI {hex(hash_djb2("Shlwapi.DLL".lower()) ^ crypt_key)}\n"
-hashes += f"#define CRYPTED_HASH_STRSTRA {hex(hash_djb2("StrStrA") ^ crypt_key)}\n"
+hashes += f'#define CRYPTED_HASH_SHLWAPI {hex(hash_djb2("Shlwapi.DLL".lower()) ^ crypt_key)}\n'
+hashes += f'#define CRYPTED_HASH_STRSTRA {hex(hash_djb2("StrStrA") ^ crypt_key)}\n'
 
 with open("api_resolve.h", "w") as _file:
     _file.write(contents.replace("//%HASHES%", hashes))


### PR DESCRIPTION
Fixed format string in generate_hashes.py in order to use the tool with older python3 versions, otherwise you get an error.